### PR TITLE
feat: use 401 bad request for invalid dates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,17 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.254
+  - repo: local
     hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-      - id: pytest
-        args: [--doctest-modules]
+      - id: ruff-check
+        name: ruff check
+        entry: ruff check
+        language: system
+        types: [python]
         pass_filenames: false
+        always_run: true
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true

--- a/api/auth.py
+++ b/api/auth.py
@@ -6,7 +6,9 @@ from app.get_context import Context
 
 from models.Signup import Signup
 from models.Token import Token
-from services.auth.create_user_and_generate_token import create_user_and_generate_token
+from services.auth.create_user_and_generate_token import (
+    create_user_and_generate_token,
+)
 from services.auth.login_and_generate_token import login_and_generate_token
 from services.auth.utils import generate_token
 
@@ -29,7 +31,8 @@ async def signup(ctx: Context, form_data: Signup) -> Token:
         result = create_user_and_generate_token(ctx, form_data)
         if result.get("status") == "KO":
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail=result.error_description
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=result.error_description,
             )
         return result.get("token")
     except Exception as e:
@@ -47,7 +50,9 @@ async def login(
     )
 
     try:
-        token = login_and_generate_token(ctx, form_data.username, form_data.password)
+        token = login_and_generate_token(
+            ctx, form_data.username, form_data.password
+        )
         if not token:
             logger.warning(
                 f"Unauthorized login for username {form_data.username}: username not found."

--- a/app/ErrorCode.py
+++ b/app/ErrorCode.py
@@ -1,6 +1,5 @@
 class ErrorCode:
     A01 = "A01"
-    A02 = "A02"
     C01 = "C01"
     C02 = "C02"
     C03 = "C03"

--- a/app/error_handling.py
+++ b/app/error_handling.py
@@ -1,14 +1,18 @@
 from app.ErrorCode import ErrorCode
 
+
 error_description_map: dict = {
-    ErrorCode.A01: "idNotFound",
-    ErrorCode.A02: "dateNotValid",
+    ErrorCode.A01: "idNotFoundInDatabase",
     ErrorCode.C01: "todoAlreadyCompleted",
     ErrorCode.C02: "todoNotCompletedYet",
     ErrorCode.C03: "remainderNotFound",
     ErrorCode.U00: "unhandledException",
     ErrorCode.Y00: "usernameAlreadyTaken",
 }
+
+
+class BadRequestDetail:
+    DATE_NOT_VALID = "date not valid"
 
 
 class ErrorModel:

--- a/services/todo/add_remainder_to_todo.py
+++ b/services/todo/add_remainder_to_todo.py
@@ -1,7 +1,6 @@
 from app.Client import Client, ReturnModel
 from app.error_handling import ErrorModel, return_error
 from app.ErrorCode import ErrorCode
-from utils.is_valid_iso_date import is_valid_iso_date
 
 
 async def add_remainder_to_todo(
@@ -10,8 +9,6 @@ async def add_remainder_to_todo(
     """
     Add a new remainder to an existing "todo" document
     """
-    if not is_valid_iso_date(remainder):
-        return return_error(ErrorCode.A02, key="payload")
 
     collection = client.get_todo_collection()
 

--- a/services/todo/delete_remainder_to_todo.py
+++ b/services/todo/delete_remainder_to_todo.py
@@ -1,7 +1,6 @@
 from app.Client import Client, ReturnModel
 from app.error_handling import ErrorModel, return_error
 from app.ErrorCode import ErrorCode
-from utils.is_valid_iso_date import is_valid_iso_date
 
 
 async def delete_remainder_to_todo(
@@ -10,8 +9,6 @@ async def delete_remainder_to_todo(
     """
     Remove an existing remainder to an existing "todo" document
     """
-    if not is_valid_iso_date(remainder):
-        return return_error(ErrorCode.A02, key="payload")
 
     collection = client.get_todo_collection()
 

--- a/services/todo/get_all_todos.py
+++ b/services/todo/get_all_todos.py
@@ -4,9 +4,7 @@ from pymongo.collection import Collection
 
 from app import Client
 from app.Client import ReturnModel
-from app.error_handling import ErrorModel, return_error
-from app.ErrorCode import ErrorCode
-from utils.is_valid_iso_date import is_valid_iso_date
+from app.error_handling import ErrorModel
 
 
 async def get_all_todos(
@@ -23,13 +21,9 @@ async def get_all_todos(
     timespan_query = {}
 
     if before is not None:
-        if not is_valid_iso_date(before):
-            return return_error(ErrorCode.A02, key="before")
         timespan_query["$lte"] = before
 
     if after is not None:
-        if not is_valid_iso_date(after):
-            return return_error(ErrorCode.A02, key="after")
         timespan_query["$gte"] = after
 
     collection: Collection = client.get_todo_collection()

--- a/services/todo/update_remainder_to_todo.py
+++ b/services/todo/update_remainder_to_todo.py
@@ -1,7 +1,6 @@
 from app.Client import Client, ReturnModel
 from app.error_handling import ErrorModel, return_error
 from app.ErrorCode import ErrorCode
-from utils.is_valid_iso_date import is_valid_iso_date
 
 
 async def update_remainder_to_todo(
@@ -14,10 +13,6 @@ async def update_remainder_to_todo(
     """
     Change a remainder, replacing an existing one with a new one, to an existing "todo" document
     """
-    if not is_valid_iso_date(old_remainder):
-        return return_error(ErrorCode.A02, key="new_remainder")
-    if not is_valid_iso_date(new_remainder):
-        return return_error(ErrorCode.A02, key="old_remainder")
 
     collection = client.get_todo_collection()
 

--- a/tests/todo/test_add_remainder_to_todo.py
+++ b/tests/todo/test_add_remainder_to_todo.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.ErrorCode import ErrorCode
+from app.error_handling import BadRequestDetail
 from app.get_context import get_context
 from main import app
 from services.auth.utils import get_current_active_user
@@ -49,10 +50,13 @@ def test_add_remainder():
 
 
 def test_fail_for_invalid_dates_in_remainder_methods():
-    assert_ko(
-        ErrorCode.A02,
-        client.patch("/todo/addRemainder/10002?new=2021-11-T16:0:00.000Z"),
-    )
+    id = "10002"
+    new = "2021-11-T16:0:00.000Z"
+    res = client.patch(f"/todo/addRemainder/{id}?new={new}")
+    assert res.status_code == 400
+    assert res.json()["detail"] == BadRequestDetail.DATE_NOT_VALID
+    assert res.json()["key"] == "new"
+    assert res.json()["value"] == new
 
 
 def test_fail_add_remainder_to_another_user_todo():

--- a/tests/todo/test_delete_remainder_to_todo.py
+++ b/tests/todo/test_delete_remainder_to_todo.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.ErrorCode import ErrorCode
+from app.error_handling import BadRequestDetail
 from app.get_context import get_context
 from main import app
 from services.auth.utils import get_current_active_user
@@ -64,10 +65,14 @@ def test_fail_to_delete_non_existing_remainder():
 
 
 def test_fail_for_invalid_dates_in_remainder_methods():
-    assert_ko(
-        ErrorCode.A02,
-        client.patch("/todo/deleteRemainder/10002?old=202111-T16:00:00.000Z"),
-    )
+    id = "10002"
+    old = "202111-T16:00:00.000Z"
+    res = client.patch(f"/todo/deleteRemainder/{id}?old={old}")
+
+    assert res.status_code == 400
+    assert res.json()["detail"] == BadRequestDetail.DATE_NOT_VALID
+    assert res.json()["key"] == "old"
+    assert res.json()["value"] == old
 
 
 def test_fail_delete_remainder_to_another_user_todo():


### PR DESCRIPTION
- Add a fix on pre-commit rules to allow the execution of `pytest` when committing

- Update API `/todo/` to return 401 in case of invalid dates